### PR TITLE
Сhange name of speakers from "Speaker" to Pulse description

### DIFF
--- a/package/contents/ui/MixerItem.qml
+++ b/package/contents/ui/MixerItem.qml
@@ -196,7 +196,7 @@ PlasmaComponents.ListItem {
 			}
 		} else if (name.indexOf('alsa_output.') === 0) {
 			if (name.indexOf('.analog-') >= 0) {
-				return i18n("Speaker")
+				return PulseObject.description
 			} else if (name.indexOf('.hdmi-') >= 0) {
 				return i18n("HDMI")
 			}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2198153/107879434-a119af00-6ed0-11eb-9d42-75a73f7e593c.png)
If speakers more then one, hard to fast understand what you need to turn on. Just provide the name of aspeaker to the panel.